### PR TITLE
missing <vector> header

### DIFF
--- a/Core/Source/Core/Renderer/Shader.cpp
+++ b/Core/Source/Core/Renderer/Shader.cpp
@@ -1,5 +1,6 @@
 #include "Shader.h"
 
+#include <vector>
 #include <iostream>
 #include <fstream>
 


### PR DESCRIPTION
On Linux (NixOS) with clang and gcc, I was getting some strange errors w/o this change.

It was puzzling, until I realized that `std::vector` was used, without `<vector>` being included.

```sh

[ 23%] Built target glad
[ 46%] Building CXX object Core/CMakeFiles/Core.dir/Source/Core/Renderer/GLUtils.cpp.o
[ 46%] Building CXX object Core/CMakeFiles/Core.dir/Source/Core/Renderer/Renderer.cpp.o
[ 53%] Building CXX object Core/CMakeFiles/Core.dir/vendor/stb/stb_image.cpp.o
[ 53%] Building CXX object Core/CMakeFiles/Core.dir/Source/Core/Application.cpp.o
[ 69%] Building CXX object Core/CMakeFiles/Core.dir/Source/Core/Window.cpp.o
[ 69%] Building CXX object Core/CMakeFiles/Core.dir/Source/Core/Renderer/Shader.cpp.o
/home/bart/src/thecherno/Architecture/Core/Source/Core/Renderer/Shader.cpp:43:9: error: too few template arguments for class template 'vector'
   43 |                         std::vector<GLchar> infoLog(maxLength);
      |                              ^
/nix/store/82kmz7r96navanrc2fgckh2bamiqrgsw-gcc-14.3.0/include/c++/14.3.0/format:2594:36: note: template is declared here
 2594 | template<typename, typename> class vector;
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^
/home/bart/src/thecherno/Architecture/Core/Source/Core/Renderer/Shader.cpp:63:9: error: too few template arguments for class template 'vector'
   63 |                         std::vector<GLchar> infoLog(maxLength);
      |                              ^
/nix/store/82kmz7r96navanrc2fgckh2bamiqrgsw-gcc-14.3.0/include/c++/14.3.0/format:2594:36: note: template is declared here
 2594 | template<typename, typename> class vector;
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^
/home/bart/src/thecherno/Architecture/Core/Source/Core/Renderer/Shader.cpp:111:9: error: too few template arguments for class template 'vector'
  111 |                         std::vector<GLchar> infoLog(maxLength);
      |                              ^
/nix/store/82kmz7r96navanrc2fgckh2bamiqrgsw-gcc-14.3.0/include/c++/14.3.0/format:2594:36: note: template is declared here
 2594 | template<typename, typename> class vector;
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^
/home/bart/src/thecherno/Architecture/Core/Source/Core/Renderer/Shader.cpp:136:9: error: too few template arguments for class template 'vector'
  136 |                         std::vector<GLchar> infoLog(maxLength);
      |                              ^
/nix/store/82kmz7r96navanrc2fgckh2bamiqrgsw-gcc-14.3.0/include/c++/14.3.0/format:2594:36: note: template is declared here
 2594 | template<typename, typename> class vector;
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^
/home/bart/src/thecherno/Architecture/Core/Source/Core/Renderer/Shader.cpp:159:9: error: too few template arguments for class template 'vector'
  159 |                         std::vector<GLchar> infoLog(maxLength);
      |                              ^
/nix/store/82kmz7r96navanrc2fgckh2bamiqrgsw-gcc-14.3.0/include/c++/14.3.0/format:2594:36: note: template is declared here
 2594 | template<typename, typename> class vector;
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^
5 errors generated.
```